### PR TITLE
fix: set type text for metadataDescription

### DIFF
--- a/src/Resources/config/doctrine/SEOContentTranslation.orm.xml
+++ b/src/Resources/config/doctrine/SEOContentTranslation.orm.xml
@@ -13,7 +13,7 @@
         </field>
 
         <field name="metadataTitle" column="seo_metadata_title" nullable="true"/>
-        <field name="metadataDescription" column="seo_metadata_description" nullable="true"/>
+        <field name="metadataDescription" column="seo_metadata_description" type="text" nullable="true"/>
 
         <field name="openGraphMetadataTitle" column="seo_og_metadata_title" nullable="true"/>
         <field name="openGraphMetadataDescription" column="seo_og_metadata_description" nullable="true"/>


### PR DESCRIPTION
Comme vu avec Hugo, le champ métadescription n'est pas sensé avoir de limite