### PR TITLE
Support Sylius ^1.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0",
-        "sylius/sylius": "~1.11 || ~1.12",
+        "sylius/sylius": "^1.11",
         "sylius/mailer-bundle":  "^1.8 || ^2.0@beta",
         "symfony/webpack-encore-bundle": "^1.15"
     },


### PR DESCRIPTION
The code of this plugin is compatible with Sylius 1.13 & 1.14, so the requirement in composer.json can be fixed.

Fixes #76 